### PR TITLE
Fix supabase auth and css import

### DIFF
--- a/z_1/app/layout.tsx
+++ b/z_1/app/layout.tsx
@@ -1,4 +1,4 @@
-import "./globals.css";
+import "../styles/globals.css";
 import PasswordProtection from "../components/PasswordProtection";
 import AuthGuard from "../components/AuthGuard";
 

--- a/z_1/hooks/useSupabaseAuth.ts
+++ b/z_1/hooks/useSupabaseAuth.ts
@@ -8,9 +8,21 @@ export function useSupabaseAuth() {
 
   useEffect(() => {
     const getSession = async () => {
-      const { data: { session } } = await supabase.auth.getSession();
-      setUser(session?.user ?? null);
-      setLoading(false);
+      try {
+        const {
+          data: { session },
+          error,
+        } = await supabase.auth.getSession();
+        if (error) {
+          console.error("Error fetching session", error);
+        }
+        setUser(session?.user ?? null);
+      } catch (err) {
+        console.error("Supabase auth error", err);
+        setUser(null);
+      } finally {
+        setLoading(false);
+      }
     };
     getSession();
 

--- a/z_1/lib/supabaseClient.ts
+++ b/z_1/lib/supabaseClient.ts
@@ -1,6 +1,13 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey); 
+if (!supabaseUrl || !supabaseAnonKey) {
+  console.warn(
+    "Supabase environment variables are missing.\n" +
+      "NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY are required."
+  );
+}
+
+export const supabase = createClient(supabaseUrl ?? "", supabaseAnonKey ?? "");


### PR DESCRIPTION
## Summary
- handle missing Supabase env vars
- add error handling for Supabase session lookup
- import global styles from shared folder

## Testing
- `pnpm dev` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687743b880708324adfa4f833d7b053c