### PR TITLE
Fix Next.js config syntax

### DIFF
--- a/z_1/next.config.mjs
+++ b/z_1/next.config.mjs
@@ -9,6 +9,6 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
-}
+};
 
-export default nextConfig
+export default nextConfig;


### PR DESCRIPTION
## Summary
- correct stray text in `next.config.mjs`

## Testing
- `npx tsc --noEmit --project z_1/tsconfig.json` *(fails: Cannot find module 'lucide-react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_687745a3303483248c79213d2e54b3dc