### PR TITLE
Fix missing login by handling Supabase variables

### DIFF
--- a/z_1/ENVIRONMENT_CONFIG.md
+++ b/z_1/ENVIRONMENT_CONFIG.md
@@ -38,6 +38,9 @@ NEXT_PUBLIC_ENABLE_FILTERS=false
 # .env.local
 NEXT_PUBLIC_OPENAI_API_KEY=your-actual-api-key-here
 NEXT_PUBLIC_ENABLE_FILTERS=false
+# Required for Supabase authentication
+NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
 ```
 
 3. Restart your development server: `pnpm dev`

--- a/z_1/lib/supabaseClient.ts
+++ b/z_1/lib/supabaseClient.ts
@@ -1,13 +1,17 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
+let client: SupabaseClient | null = null;
+
 if (!supabaseUrl || !supabaseAnonKey) {
   console.warn(
-    "Supabase environment variables are missing.\n" +
-      "NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY are required."
+    'Supabase environment variables are missing.\n' +
+      'NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY are required.'
   );
+} else {
+  client = createClient(supabaseUrl, supabaseAnonKey);
 }
 
-export const supabase = createClient(supabaseUrl ?? "", supabaseAnonKey ?? "");
+export const supabase = client;


### PR DESCRIPTION
## Summary
- handle undefined Supabase credentials so build/dev don't fail
- guard auth hook when Supabase is not configured
- document required Supabase variables in `ENVIRONMENT_CONFIG.md`

## Testing
- `./build.sh`
- `./dev.sh`

------
https://chatgpt.com/codex/tasks/task_e_68774aa63260832483619084fb56c5ec