### PR TITLE
Fix CSS import quoting

### DIFF
--- a/z_1/styles/globals.css
+++ b/z_1/styles/globals.css
@@ -4,7 +4,7 @@
 
 /* Import Gotham and Dharma Gothic C Heavy fonts */
 /* Note: You'll need to purchase and host these fonts or use a font service */
-@import url('https://fonts.example.com/css?family=Gotham:400,700,900&display=swap');
+@import url("https://fonts.example.com/css?family=Gotham:400,700,900&display=swap");
 /* Replace the above with actual font imports when available */
 
 body {


### PR DESCRIPTION
## Summary
- escape font import with double quotes

## Testing
- `./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_68775112ea3c8324a5a58d83b429be74