### PR TITLE
Implement asset add/delete functions

### DIFF
--- a/z_1/app/api/tools/[id]/route.ts
+++ b/z_1/app/api/tools/[id]/route.ts
@@ -1,21 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
-import fs from 'fs';
-import path from 'path';
-
-const dataFilePath = path.join(process.cwd(), 'z_1/config/data.json');
+import { removeAsset } from '@/lib/assetManager';
 
 export async function DELETE(request: NextRequest, { params }: { params: { id: string } }) {
   try {
     const id = params.id;
-    const data = JSON.parse(fs.readFileSync(dataFilePath, 'utf-8'));
-    const originalLength = data.tools.length;
-    data.tools = data.tools.filter((tool: any) => tool.id !== id);
-    if (data.tools.length === originalLength) {
+    const removed = removeAsset(id);
+    if (!removed) {
       return NextResponse.json({ error: 'Tool not found' }, { status: 404 });
     }
-    fs.writeFileSync(dataFilePath, JSON.stringify(data, null, 2), 'utf-8');
     return NextResponse.json({ success: true });
   } catch (error) {
     return NextResponse.json({ error: error instanceof Error ? error.message : 'Unknown error' }, { status: 500 });
   }
-} 
+}

--- a/z_1/app/api/tools/route.ts
+++ b/z_1/app/api/tools/route.ts
@@ -1,24 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
-import fs from 'fs';
-import path from 'path';
-
-const dataFilePath = path.join(process.cwd(), 'z_1/config/data.json');
+import { addAsset } from '@/lib/assetManager';
 
 export async function POST(request: NextRequest) {
   try {
-    const newTool = await request.json();
-    const data = JSON.parse(fs.readFileSync(dataFilePath, 'utf-8'));
-    // Ensure unique ID
-    if (!newTool.id) {
-      newTool.id = Date.now().toString();
-    }
-    const now = new Date().toISOString();
-    newTool.date_added = now;
-    newTool.date_modified = now;
-    data.tools.push(newTool);
-    fs.writeFileSync(dataFilePath, JSON.stringify(data, null, 2), 'utf-8');
-    return NextResponse.json({ success: true, tool: newTool });
+    const assetData = await request.json();
+    const newAsset = addAsset(assetData);
+    return NextResponse.json({ success: true, tool: newAsset });
   } catch (error) {
     return NextResponse.json({ error: error instanceof Error ? error.message : 'Unknown error' }, { status: 500 });
   }
-} 
+}

--- a/z_1/components/CuratorDashboard.tsx
+++ b/z_1/components/CuratorDashboard.tsx
@@ -314,11 +314,17 @@ export function CuratorDashboard({ className }: CuratorDashboardProps) {
                                 </button>
                                 <button
                                   className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700"
-                                  onClick={() => {
-                                    setTools((prev) =>
-                                      prev.filter((t) => t.id !== tool.id)
-                                    );
-                                    setDeleteConfirmId(null);
+                                  onClick={async () => {
+                                    try {
+                                      const res = await fetch(`/api/tools/${tool.id}`, {
+                                        method: "DELETE",
+                                      });
+                                      if (res.ok) {
+                                        setTools((prev) => prev.filter((t) => t.id !== tool.id));
+                                      }
+                                    } finally {
+                                      setDeleteConfirmId(null);
+                                    }
                                   }}
                                 >
                                   Delete

--- a/z_1/lib/assetManager.ts
+++ b/z_1/lib/assetManager.ts
@@ -1,0 +1,77 @@
+export interface SchemaField {
+  name: string;
+  type: string;
+  required?: boolean;
+  generated?: boolean;
+}
+
+export interface Asset {
+  [key: string]: any;
+}
+
+import fs from 'fs';
+import path from 'path';
+
+const dataFilePath = path.join(process.cwd(), 'z_1/config/data.json');
+const schemaFilePath = path.join(process.cwd(), 'z_1/data/schema.json');
+
+function loadSchema(): { fields: SchemaField[] } {
+  const raw = fs.readFileSync(schemaFilePath, 'utf-8');
+  return JSON.parse(raw);
+}
+
+function loadData() {
+  const raw = fs.readFileSync(dataFilePath, 'utf-8');
+  return JSON.parse(raw);
+}
+
+function saveData(data: any) {
+  fs.writeFileSync(dataFilePath, JSON.stringify(data, null, 2), 'utf-8');
+}
+
+/**
+ * Add a new asset to data.json using the schema definition
+ */
+export function addAsset(asset: Asset) {
+  const schema = loadSchema();
+  const data = loadData();
+
+  const newAsset: Asset = {};
+  for (const field of schema.fields) {
+    if (field.generated && field.name === 'id') {
+      newAsset.id = asset.id || Date.now().toString();
+      continue;
+    }
+    if (field.name === 'date_created') {
+      newAsset.date_created = asset.date_created || new Date().toISOString();
+      continue;
+    }
+    if (field.name === 'date_modified') {
+      newAsset.date_modified = new Date().toISOString();
+      continue;
+    }
+    if (asset[field.name] !== undefined) {
+      newAsset[field.name] = asset[field.name];
+    } else if (field.required) {
+      newAsset[field.name] = field.type === 'array' ? [] : '';
+    }
+  }
+
+  data.tools.push(newAsset);
+  saveData(data);
+  return newAsset;
+}
+
+/**
+ * Remove an asset by id from data.json
+ */
+export function removeAsset(id: string) {
+  const data = loadData();
+  const originalLength = data.tools.length;
+  data.tools = data.tools.filter((t: any) => t.id !== id);
+  if (data.tools.length === originalLength) {
+    return false;
+  }
+  saveData(data);
+  return true;
+}


### PR DESCRIPTION
## Summary
- create `assetManager` with helpers to add and remove assets using schema
- use new helpers in API routes
- call API delete endpoint from curator dashboard when removing an asset

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6880da39206083258b8dd4223ddad525