### PR TITLE
Migrate configs to Upstash Redis

### DIFF
--- a/z_1/app/api/config/[type]/route.ts
+++ b/z_1/app/api/config/[type]/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  getConfig,
+  setConfig,
+  deleteConfig,
+} from "@/lib/redisConfigManager";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { type: string } }
+) {
+  const { type } = params;
+  const config = await getConfig(type as any);
+  return NextResponse.json(config);
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { type: string } }
+) {
+  const { type } = params;
+  const body = await req.json();
+  await setConfig(type as any, body);
+  return NextResponse.json({ success: true });
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: { type: string } }
+) {
+  const { type } = params;
+  await deleteConfig(type as any);
+  return NextResponse.json({ success: true });
+}
+

--- a/z_1/lib/configManager.ts
+++ b/z_1/lib/configManager.ts
@@ -3,6 +3,11 @@ import type { ZenoAsset, ZenoConfig } from '../types/config';
 import appConfigData from '../public/config/app-config.json';
 import contentConfigData from '../public/config/content.json';
 import dataConfigData from '../public/config/data.json';
+import {
+  getAppConfig as fetchAppConfig,
+  getContentConfig as fetchContentConfig,
+  getDataConfig as fetchDataConfig,
+} from './redisConfigManager';
 
 /**
  * ConfigManager - Centralized configuration management
@@ -18,6 +23,22 @@ class ConfigManager {
     this.appConfig = appConfigData as any;
     this.contentConfig = contentConfigData as any;
     this.dataConfig = dataConfigData as ZenoConfig;
+    this.loadFromRedis();
+  }
+
+  private async loadFromRedis() {
+    try {
+      const [app, content, data] = await Promise.all([
+        fetchAppConfig(),
+        fetchContentConfig(),
+        fetchDataConfig(),
+      ]);
+      if (app) this.appConfig = app;
+      if (content) this.contentConfig = content;
+      if (data) this.dataConfig = data as ZenoConfig;
+    } catch (error) {
+      console.warn('Failed to load config from Redis:', error);
+    }
   }
 
   /**

--- a/z_1/lib/redisConfigManager.ts
+++ b/z_1/lib/redisConfigManager.ts
@@ -1,0 +1,37 @@
+import { Redis } from "@upstash/redis";
+
+const redis = Redis.fromEnv();
+
+const CONFIG_KEYS = {
+  app: "app-config",
+  content: "content-config",
+  data: "data-config",
+  taxonomy: "taxonomy-config",
+} as const;
+
+type ConfigKey = keyof typeof CONFIG_KEYS;
+
+export async function getConfig(key: ConfigKey) {
+  return await redis.get(CONFIG_KEYS[key]);
+}
+
+export async function setConfig(key: ConfigKey, value: unknown) {
+  return await redis.set(CONFIG_KEYS[key], value);
+}
+
+export async function deleteConfig(key: ConfigKey) {
+  return await redis.del(CONFIG_KEYS[key]);
+}
+
+export const getAppConfig = () => getConfig("app");
+export const setAppConfig = (value: unknown) => setConfig("app", value);
+
+export const getContentConfig = () => getConfig("content");
+export const setContentConfig = (value: unknown) => setConfig("content", value);
+
+export const getDataConfig = () => getConfig("data");
+export const setDataConfig = (value: unknown) => setConfig("data", value);
+
+export const getTaxonomyConfig = () => getConfig("taxonomy");
+export const setTaxonomyConfig = (value: unknown) => setConfig("taxonomy", value);
+

--- a/z_1/package.json
+++ b/z_1/package.json
@@ -60,7 +60,8 @@
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^1.1.2",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "@upstash/redis": "^1.35.1"
   },
   "devDependencies": {
     "@types/node": "^22",

--- a/z_1/tools/seedRedisConfigs.ts
+++ b/z_1/tools/seedRedisConfigs.ts
@@ -1,0 +1,33 @@
+import fs from "fs";
+import path from "path";
+import {
+  setAppConfig,
+  setContentConfig,
+  setDataConfig,
+  setTaxonomyConfig,
+} from "../lib/redisConfigManager";
+
+async function seedConfigs() {
+  const base = path.join(process.cwd(), "z_1/public/config");
+
+  await setAppConfig(
+    JSON.parse(fs.readFileSync(path.join(base, "app-config.json"), "utf-8"))
+  );
+
+  await setContentConfig(
+    JSON.parse(fs.readFileSync(path.join(base, "content.json"), "utf-8"))
+  );
+
+  await setDataConfig(
+    JSON.parse(fs.readFileSync(path.join(base, "data.json"), "utf-8"))
+  );
+
+  await setTaxonomyConfig(
+    JSON.parse(fs.readFileSync(path.join(base, "taxonomy.json"), "utf-8"))
+  );
+
+  console.log("Configs seeded to Redis!");
+}
+
+seedConfigs();
+


### PR DESCRIPTION
## Summary
- add redisConfigManager for interacting with Upstash
- seed Redis with existing config files
- expose new `/api/config/[type]` endpoint
- load Redis configs in ConfigManager
- depend on `@upstash/redis`

## Testing
- `pnpm lint` *(fails: next not found because dependencies are missing)*

------
https://chatgpt.com/codex/tasks/task_b_6880e786fa7c8325a13ac0aedaa31a05